### PR TITLE
Add rake install and configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ TODO
 /coverage/*
 .rspec_status
 *.gem
+/config/*
 *.development
 *.test

--- a/README.md
+++ b/README.md
@@ -14,6 +14,31 @@ Add this line to your application's Gemfile:
 gem 'falcon', github: 'petlove/falcon'
 ```
 
+and run:
+
+```
+rails falcon:install
+```
+
+## Settings
+Set the settings in the file _config/initializers/falcon.rb_:
+
+```ruby
+# frozen_string_literal: true
+
+Falcon.configure do |config|
+  # config.add :option_name, option_params_hash
+  # config.add :parse,
+  #            raise_error: true,
+  #            url: ENV['PARSE_URL'],
+  #            header: {
+  #              'Content-Type' => 'application/json',
+  #              'X-Parse-Application-Id' => ENV['PARSE_APPLICATION_ID'],
+  #              'X-Parse-REST-API-Key' => ENV['PARSE_REST_API_KEY']
+  #            }
+end
+```
+
 ## Using
 
 To use this gem, you can extend the module `Falcon::Client` and set the options. You could set the options before through the method `falcon_options` or direct in the request method, like:
@@ -29,13 +54,19 @@ module Cloudflare
 
       RECORD_ALREADY_EXIST_ERROR_MESSAGE = 'The record already exists.'
 
-    falcon_options raise_error: true,
+      falcon_options raise_error: true,
                      url: 'https://api.cloudflare.com/client/v4/',
                      path: "zones/#{ENV['CLOUDFLARE_WHITELABEL_ZONE_ID']}/dns_records",
                      headers: {
                        'Content-Type' => 'application/json',
                        'Authorization' => ENV['CLOUDFLARE_API_TOKEN']
                      }
+
+      ## If you add the option in the initilializer you can do it:
+      ## falcon_option :cloudflare
+
+      ## If you want to customize the option saved you cad do it:
+      ## falcon_option :cloudflare, suffix: 20, raise_error: false
 
       class << self
         def find!(name)

--- a/falcon.gemspec
+++ b/falcon.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://https://github.com/petlove/falcon'
   spec.license       = 'MIT'
 
-  spec.files         = Dir['{lib}/**/*', 'CHANGELOG.md', 'MIT-LICENSE', 'README.md']
+  spec.files         = Dir['{config,lib}/**/*', 'CHANGELOG.md', 'MIT-LICENSE', 'README.md']
 
   spec.add_dependency 'faraday', '>= 0.17.0'
 

--- a/lib/falcon.rb
+++ b/lib/falcon.rb
@@ -2,9 +2,19 @@
 
 require 'falcon/version'
 require 'falcon/options'
+require 'falcon/configuration'
 require 'falcon/response'
 require 'falcon/error'
 require 'falcon/client'
 
 module Falcon
+  require 'falcon/railtie' if defined?(Rails)
+
+  def self.configure
+    yield(configuration)
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
 end

--- a/lib/falcon/client.rb
+++ b/lib/falcon/client.rb
@@ -6,11 +6,13 @@ require 'json'
 module Falcon
   module Client
     def self.extended(base)
-      base.define_singleton_method(:falcon_default_options) { @falcon_default_options }
+      base.define_singleton_method(:falcon_default_options) { Falcon.configuration.option(name, options) }
     end
 
-    def falcon_options(options)
-      define_singleton_method(:falcon_default_options) { @falcon_default_options ||= Options.new(options) }
+    def falcon_options(name, options = {})
+      define_singleton_method(:falcon_default_options) do
+        @falcon_default_options ||= Falcon.configuration.option(name, options)
+      end
     end
 
     def get(options = {})

--- a/lib/falcon/configuration.rb
+++ b/lib/falcon/configuration.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Falcon
+  class Configuration
+    attr_reader :options
+
+    def initialize
+      @options = {}
+    end
+
+    def add(name, options)
+      return unless name && options
+
+      @options.merge!(name => Options.new(options))
+    end
+
+    def option(name, options)
+      update_option(option_by_name(name), options)
+    end
+
+    private
+
+    def option_by_name(name)
+      name.is_a?(Hash) ? Options.new(name) : find_option(name)
+    end
+
+    def update_option(option, options)
+      options.is_a?(Hash) && option.is_a?(Options) ? option.clone!(options) : option
+    end
+
+    def find_option(name)
+      @options[name] || Options.new
+    end
+  end
+end

--- a/lib/falcon/options.rb
+++ b/lib/falcon/options.rb
@@ -23,7 +23,7 @@ module Falcon
     end
 
     def attributes!(options)
-      options.slice(*ACCESSORS).each { |k, v| instance_variable_set("@#{k}", v) }
+      options.to_h.slice(*ACCESSORS).each { |k, v| instance_variable_set("@#{k}", v) }
     end
 
     private

--- a/lib/falcon/railtie.rb
+++ b/lib/falcon/railtie.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'falcon'
+require 'rails'
+
+module Falcon
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      Dir[File.join(File.dirname(__FILE__), 'tasks/*.rake')].each { |f| load f }
+    end
+  end
+end

--- a/lib/falcon/tasks/setup.rake
+++ b/lib/falcon/tasks/setup.rake
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+FALCON_INITILIAZER_FILE = 'config/initializers/falcon.rb'
+
+namespace :falcon do
+  desc 'Install Falcon'
+  task :install do
+    create_initializer
+  end
+end
+
+def create_initializer
+  FileUtils.mkdir_p(File.dirname(FALCON_INITILIAZER_FILE))
+  File.open(FALCON_INITILIAZER_FILE, 'w') { |file| file << settings }
+end
+
+def settings
+  <<~SETTINGS
+    # frozen_string_literal: true
+
+    Falcon.configure do |config|
+      # config.add :parse,
+      #            raise_error: true,
+      #            url: ENV['PARSE_URL'],
+      #            header: {
+      #              'Content-Type' => 'application/json',
+      #              'X-Parse-Application-Id' => ENV['PARSE_APPLICATION_ID'],
+      #              'X-Parse-REST-API-Key' => ENV['PARSE_REST_API_KEY']
+      #            }
+    end
+  SETTINGS
+end

--- a/lib/falcon/tasks/setup.rake
+++ b/lib/falcon/tasks/setup.rake
@@ -21,6 +21,7 @@ def settings
     # frozen_string_literal: true
 
     Falcon.configure do |config|
+      # config.add :option_name, option_params_hash
       # config.add :parse,
       #            raise_error: true,
       #            url: ENV['PARSE_URL'],

--- a/spec/falcon_spec.rb
+++ b/spec/falcon_spec.rb
@@ -1,5 +1,47 @@
 # frozen_string_literal: true
 
+require 'securerandom'
+
 RSpec.describe Falcon, type: :module do
   it { expect(described_class::VERSION).not_to be_nil }
+
+  describe '.configure' do
+    subject do
+      described_class.configure do |config|
+        config.add :parse,
+                   raise_error: true,
+                   url: url,
+                   headers: {
+                     'Content-Type' => 'application/json',
+                     'X-Parse-Application-Id' => application_id,
+                     'X-Parse-REST-API-Key' => rest_api_key
+                   }
+      end
+    end
+
+    let(:url) { 'https://parse.parseaccount.com.br/parse/users' }
+    let(:application_id) { SecureRandom.uuid }
+    let(:rest_api_key) { SecureRandom.uuid }
+
+    before { subject }
+
+    it { expect(described_class.configuration.options.length).to eq(1) }
+    it do
+      expect(described_class.configuration.options[:parse]).to have_attributes(
+        raise_error: true,
+        url: url,
+        headers: {
+          'Content-Type' => 'application/json',
+          'X-Parse-Application-Id' => application_id,
+          'X-Parse-REST-API-Key' => rest_api_key
+        }
+      )
+    end
+  end
+
+  describe '.configuration' do
+    subject { described_class.configuration }
+
+    it { is_expected.to be_a(described_class::Configuration) }
+  end
 end

--- a/spec/lib/falcon/configuration_spec.rb
+++ b/spec/lib/falcon/configuration_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'securerandom'
+
+RSpec.describe Falcon::Configuration, type: :model do
+  describe '#initialize' do
+    subject { described_class.new }
+
+    it { is_expected.to have_attributes(options: {}) }
+  end
+
+  describe '#add' do
+    subject { instance.add(name, options) }
+
+    let(:instance) { described_class.new }
+    let(:name) { :parse }
+    let(:options) do
+      {
+        raise_error: true,
+        url: url,
+        headers: {
+          'Content-Type' => 'application/json',
+          'X-Parse-Application-Id' => application_id,
+          'X-Parse-REST-API-Key' => rest_api_key
+        }
+      }
+    end
+    let(:url) { 'https://parse.parseaccount.com.br/parse/users' }
+    let(:application_id) { SecureRandom.uuid }
+    let(:rest_api_key) { SecureRandom.uuid }
+
+    before { subject }
+
+    it { expect(instance.options).not_to be_empty }
+    it do
+      expect(instance.options[:parse]).to have_attributes(
+        raise_error: true,
+        url: url,
+        headers: {
+          'Content-Type' => 'application/json',
+          'X-Parse-Application-Id' => application_id,
+          'X-Parse-REST-API-Key' => rest_api_key
+        }
+      )
+    end
+  end
+
+  describe '#option' do
+    subject { instance.option(name, options) }
+
+    let(:instance) { described_class.new }
+    let(:default_options) do
+      {
+        raise_error: true,
+        url: 'https://parse.parseaccount.com.br',
+        headers: {
+          'Content-Type' => 'application/json',
+          'X-Parse-Application-Id' => SecureRandom.uuid,
+          'X-Parse-REST-API-Key' => SecureRandom.uuid
+        },
+        path: 'parse/users',
+        params: { a: 'a' },
+        payload: { b: 'b' },
+        suffix: 10
+      }
+    end
+
+    before { instance.add(:parse, default_options) }
+
+    context 'without name and options' do
+      let(:name) { nil }
+      let(:options) { nil }
+
+      it { is_expected.to be_a(Falcon::Options) }
+      it do
+        is_expected.to have_attributes(
+          raise_error: nil,
+          url: nil,
+          headers: nil,
+          path: nil,
+          params: nil,
+          payload: nil,
+          after: nil,
+          suffix: nil
+        )
+      end
+    end
+
+    context 'with just name' do
+      let(:options) { nil }
+
+      context 'when name is a hash' do
+        let(:name) { default_options }
+
+        it { is_expected.to be_a(Falcon::Options) }
+        it { is_expected.to have_attributes(default_options) }
+      end
+
+      context 'when name is a string' do
+        context 'when name does not exist' do
+          let(:name) { :local }
+
+          it { is_expected.to be_a(Falcon::Options) }
+          it do
+            is_expected.to have_attributes(
+              raise_error: nil,
+              url: nil,
+              headers: nil,
+              path: nil,
+              params: nil,
+              payload: nil,
+              after: nil,
+              suffix: nil
+            )
+          end
+        end
+
+        context 'when name does not exist' do
+          let(:name) { :parse }
+
+          it { is_expected.to be_a(Falcon::Options) }
+          it { is_expected.to have_attributes(default_options) }
+        end
+      end
+    end
+
+    context 'with name and options' do
+      let(:options) { { suffix: 20 } }
+
+      context 'when name is a hash' do
+        let(:name) { default_options }
+
+        it { is_expected.to be_a(Falcon::Options) }
+        it { is_expected.to have_attributes(default_options.merge(suffix: 20)) }
+      end
+
+      context 'when name is a string' do
+        context 'when name does not exist' do
+          let(:name) { :local }
+
+          it { is_expected.to be_a(Falcon::Options) }
+          it do
+            is_expected.to have_attributes(
+              raise_error: nil,
+              url: nil,
+              headers: nil,
+              path: nil,
+              params: nil,
+              payload: nil,
+              after: nil,
+              suffix: 20
+            )
+          end
+        end
+
+        context 'when name does not exist' do
+          let(:name) { :parse }
+
+          it { is_expected.to be_a(Falcon::Options) }
+          it { is_expected.to have_attributes(default_options.merge(suffix: 20)) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adiciona a possibilidade de configurar os serviços em um arquivo de configuração.

O ganho disso é que usando Rails da para abstrair isso dentro dos secrets e só atribuir ao segundo parâmetro. Fora que se caso for consumido mais de um recurso no mesmo sistema, como /users e /sessions, é possivel definir um defaul e em cada um deles só definir o path.

Veja o readme para entender melhor.